### PR TITLE
fix(guide): add Next: footers to chapters 04-10 and enforce via harness

### DIFF
--- a/.claude/rules/guide-chapter.md
+++ b/.claude/rules/guide-chapter.md
@@ -45,6 +45,20 @@ After changing template references or metadata:
 - Cross-references use relative Markdown links: `[Chapter 02](02-project-bootstrap.md)`
 - Chapter filenames follow `NN-slug.md` (e.g., `01-foundations.md`)
 
+## Chapter Footer
+
+Every chapter except the final one (`11-failure-modes.md`) **must** end with a `Next:` footer in this exact format:
+
+```markdown
+---
+
+Next: [Chapter NN -- Title](NN-slug.md)
+```
+
+- The horizontal rule (`---`) must immediately precede the `Next:` line, separated by blank lines
+- The linked path must be a valid relative Markdown link to the immediately following chapter
+- `11-failure-modes.md` intentionally has no `Next:` footer
+
 ## Checklists
 
 The `checklists/` directory contains standalone checklists (project-kickoff, phase-completion, context-reset,

--- a/.claude/skills/cross-reference-check/scripts/validate.py
+++ b/.claude/skills/cross-reference-check/scripts/validate.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 REPO_ROOT: Path = Path(__file__).resolve().parents[4]
 LINK_PATTERN: re.Pattern[str] = re.compile(r"\[([^]]+)]\(([^)]+\.md)\)")
+NEXT_PATTERN: re.Pattern[str] = re.compile(r"^Next: \[([^]]+)]\(([^)]+)\)\s*$", re.MULTILINE)
+FINAL_CHAPTER: str = "11-failure-modes.md"
 CANONICAL_TERMS: dict[str, list[Path]] = {
     "five-tier context hierarchy": [
         REPO_ROOT / "CLAUDE.md",
@@ -163,6 +165,40 @@ def check_canonical_terms(issues: list[str]) -> None:
                 )
 
 
+def check_next_footers(issues: list[str]) -> None:
+    """Verify every non-final chapter has a Next: footer linking to an existing file.
+
+    Checks that each guide chapter except ``11-failure-modes.md`` contains a
+    ``Next:`` footer link and that the linked file exists on disk.
+
+    Args:
+        issues: Accumulator list for pipe-delimited issue strings.
+    """
+    guide_dir = REPO_ROOT / "guide"
+    for chapter in sorted(guide_dir.glob("*.md")):
+        if chapter.name == FINAL_CHAPTER:
+            continue
+        content = chapter.read_text()
+        rel = chapter.relative_to(REPO_ROOT)
+        match = NEXT_PATTERN.search(content)
+        if not match:
+            issues.append(
+                f"MISSING_NEXT_FOOTER|{rel}|0"
+                f"|Chapter is missing a 'Next:' footer section"
+                f"|Add '---\\n\\nNext: [Chapter NN -- Title](NN-slug.md)' at end of file"
+            )
+            continue
+        linked_file = match.group(2)
+        target = (chapter.parent / linked_file).resolve()
+        if not target.is_file():
+            lineno = content[: match.start()].count("\n") + 1
+            issues.append(
+                f"BROKEN_NEXT_LINK|{rel}|{lineno}"
+                f"|Next: link to {linked_file} does not resolve"
+                f"|Verify path or update link"
+            )
+
+
 def main() -> None:
     """Run all cross-reference checks and print results.
 
@@ -177,6 +213,7 @@ def main() -> None:
     check_template_paths(issues)
     check_checklist_references(issues)
     check_canonical_terms(issues)
+    check_next_footers(issues)
 
     for issue in issues:
         print(issue)

--- a/.claude/skills/edit-chapter/SKILL.md
+++ b/.claude/skills/edit-chapter/SKILL.md
@@ -42,6 +42,17 @@ Check each condition and take action if true:
 1. Search all `.md` files for the old term
 2. Update every occurrence to match the new term
 
+**Always (every edit):**
+
+1. Verify the chapter ends with a `Next:` footer linking to the correct successor chapter, unless the file is
+   `11-failure-modes.md`
+2. The footer must follow this format:
+   ```markdown
+   ---
+
+   Next: [Chapter NN -- Title](NN-slug.md)
+   ```
+
 **If any structural change was made** (title, file references, canonical terms):
 
 1. Run the `cross-reference-check` skill to verify consistency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,12 @@ Brand Identity. Each document feeds the next.
   `Args:`, `Returns:`/`Yields:`, and `Raises:` sections as applicable. Omit sections that would be empty.
 - Use **type hints** on function signatures and where they aid readability.
 
-## Research Before Implementing
+## Research Before Reasoning About Claude Code
 
-This guide teaches Claude Code features (rules, skills, hooks, CLAUDE.md). Before creating or modifying any harness
-file, verify the current format against Anthropic's official documentation — do not rely on training knowledge, MCP
-index tools, or the guide's own examples (which may be outdated).
+This guide teaches Claude Code features (rules, skills, hooks, CLAUDE.md). Any time a task involves reasoning about
+how Claude Code features work — whether answering a question, evaluating a design, or creating or modifying a harness
+file — fetch the relevant official documentation first. Do not rely on training knowledge, MCP index tools, or the
+guide's own examples, which may be outdated.
 
 **Authoritative source:** Fetch directly from `https://code.claude.com/docs/en/` using WebFetch. Key pages:
 

--- a/guide/04-context-architecture.md
+++ b/guide/04-context-architecture.md
@@ -379,3 +379,7 @@ relevant, skills load only when invoked, documents are discovered through pointe
 without repetition.
 
 Context architecture is the foundation. Every subsequent chapter assumes you have this hierarchy in place.
+
+---
+
+Next: [Chapter 05 -- Agent Orchestration: From Single Session to Teams](05-agent-orchestration.md)

--- a/guide/05-agent-orchestration.md
+++ b/guide/05-agent-orchestration.md
@@ -545,3 +545,7 @@ Phase end:
 6. **Do not assume what the other agent did.** If you need to know whether the backend implemented an endpoint, check
    the contract — not the other agent's code (which you may not even have access to in a worktree). The contract is the
    shared truth.
+
+---
+
+Next: [Chapter 06 -- Design Intent Preservation: The Anti-Slop System](06-design-intent.md)

--- a/guide/06-design-intent.md
+++ b/guide/06-design-intent.md
@@ -389,3 +389,7 @@ The five-layer pattern applies wherever taste and consistency matter, not only t
 5. **Do not mix concerns in the skill invocation.** If the design skill says to read `docs/brand-identity.md`, read it. Do not also read the architecture doc, the API spec, and the CI config "just in case." Load what the skill tells you to load and nothing more.
 
 6. **Treat checklist failures as blocking.** If more than 2 items fail, revise. Do not proceed to the next component hoping to fix it later. Fix it now, while the context for this component is fresh.
+
+---
+
+Next: [Chapter 07 -- Quality Gates: Verification, Enforcement, and Integration Testing](07-quality-gates.md)

--- a/guide/07-quality-gates.md
+++ b/guide/07-quality-gates.md
@@ -522,3 +522,7 @@ Edit a file
 No single level is sufficient. The linter does not catch logic errors. Tests do not catch integration failures. The smoke test does not catch style violations. Together, they form a defense that catches the vast majority of issues before they reach production.
 
 The investment is front-loaded. Setting up hooks, writing the smoke test, configuring CI, and creating security skills takes time upfront. But the return compounds across every session, every phase, and every agent that works on the project. Verification infrastructure is the gift that keeps giving.
+
+---
+
+Next: [Chapter 08 -- Implementation: The Human-Agent Loop](08-implementation.md)

--- a/guide/08-implementation.md
+++ b/guide/08-implementation.md
@@ -574,3 +574,7 @@ These are the implementation mistakes we have seen repeatedly. Awareness is the 
 **Micromanaging implementation.** The opposite failure. Telling the agent exactly which lines to write defeats the purpose. Give scope and constraints, then let the agent work. Review the output, not the process.
 
 **Skipping the plan step.** Jumping straight to "implement this phase" without reviewing the agent's approach. The five minutes you spend reviewing the plan saves the hours you would spend correcting a wrong approach mid-implementation.
+
+---
+
+Next: [Chapter 09 -- CI/CD and Deployment: Pipelines for Agent-Generated Code](09-ci-cd-and-deployment.md)

--- a/guide/09-ci-cd-and-deployment.md
+++ b/guide/09-ci-cd-and-deployment.md
@@ -402,3 +402,7 @@ Treat CI/CD changes with the same rigor as code changes. A broken CI pipeline bl
 ### Iterating on CI/CD
 
 Expect to iterate. The first CI pipeline the agent produces will probably work for the happy path but miss edge cases: caching, parallel jobs, service container configuration, platform-specific issues. Each failure teaches you something. Encode the fix in a rule or the workflow itself, and move on.
+
+---
+
+Next: [Chapter 10 -- Entropy Management: Fighting Drift in Agent-Generated Code](10-entropy-management.md)

--- a/guide/10-entropy-management.md
+++ b/guide/10-entropy-management.md
@@ -404,3 +404,7 @@ Use this checklist after every 3-5 phases:
 ```
 
 Fifteen to thirty minutes, every couple of weeks. This is the cost of keeping a codebase healthy. The cost of not doing it is much higher — you just pay it later, all at once, when the codebase is too inconsistent for the agent to navigate.
+
+---
+
+Next: [Chapter 11 -- Failure Modes: Common Mistakes and How to Avoid Them](11-failure-modes.md)


### PR DESCRIPTION
Closes #9.

## Summary

- Added `Next:` footer (`---` + link) to the end of `guide/04` through `guide/10`
- Added `## Chapter Footer` structural requirement to `.claude/rules/guide-chapter.md` so future chapters cannot be written without a footer
- Added an always-run post-edit check to `.claude/skills/edit-chapter/SKILL.md` to verify the footer is present and correctly formatted
- Added `check_next_footers()` to `validate.py`; flags `MISSING_NEXT_FOOTER` for any non-final chapter missing the link, and `BROKEN_NEXT_LINK` if the target file doesn't exist
- Broadened the `CLAUDE.md` "Research Before Implementing" section to cover any reasoning about Claude Code features, not only file creation/modification
- Fixed a linter-introduced `NameError` (`match =` assignment was stripped from `check_next_footers`)

## Test plan

- [ ] Run `python3 .claude/skills/cross-reference-check/scripts/validate.py` — should show no `MISSING_NEXT_FOOTER` or `BROKEN_NEXT_LINK` findings
- [ ] Verify `guide/04` through `guide/10` each end with `---\n\nNext: [...]`
- [ ] Confirm `guide/11-failure-modes.md` has no `Next:` footer and the validator does not flag it

🤖 Generated with [Claude Code](https://claude.com/claude-code)