### PR TITLE
docs: add full-lifecycle cheatsheet with copy-paste prompts

### DIFF
--- a/.claude/rules/root-files.md
+++ b/.claude/rules/root-files.md
@@ -2,6 +2,7 @@
 paths:
   - "README.md"
   - "CLAUDE.md"
+  - "CHEATSHEET.md"
 ---
 
 # Root File Editing Rules
@@ -16,6 +17,12 @@ update the corresponding README entry.
 - Must stay under 200 lines total
 - The Cross-Reference Registry section is the authoritative map of dependencies — keep it current when adding or
   renaming files
+
+## CHEATSHEET.md
+
+- Must stay under 200 lines total
+- Contains exactly 9 phases (0-8), each with: human action, blockquote prompt, verify step, and chapter link
+- Prompts use `[square bracket placeholders]` for project-specific values — no fictional examples
 
 ## Canonical Terms
 

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,0 +1,145 @@
+# Cheatsheet: Full-Lifecycle Quick Reference
+
+Copy-paste prompts for every phase of a harness-engineered project. Each phase gives you one human
+action, one agent prompt, and one verification step. For depth, follow the chapter link.
+
+---
+
+## Phase 0: Prerequisites
+
+- Claude Code CLI installed and authenticated
+- Git initialized (or ready to init)
+- A rough idea of what you want to build
+
+## Phase 1: Interview (Chapter 02)
+
+**You:** Sit down and answer the agent's questions about your project. Do not skip this — the interview
+summary feeds every document that follows.
+
+> Run a structured interview to understand my project idea. Ask me questions one at a time covering:
+> problem statement, target users, core features for the MVP, tech stack preferences, known
+> constraints, and deployment target. When done, write the summary to `docs/interview-summary.md`
+> using the template at `templates/docs/interview-summary.md`.
+
+**Verify:** `docs/interview-summary.md` exists and covers all six areas.
+**Depth:** [Chapter 02 -- Project Bootstrap](guide/02-project-bootstrap.md)
+
+## Phase 2: Scaffold (Chapter 02)
+
+**You:** Let the agent create the repo skeleton, initial CLAUDE.md, and a hello-world that proves the
+stack works end to end.
+
+> Bootstrap this project based on `docs/interview-summary.md`. Create the directory structure,
+> initialize the tech stack, write a CLAUDE.md under 200 lines, and produce a minimal hello-world
+> that I can run to verify the stack works. Commit when done.
+
+**Verify:** You can run the hello-world locally and see output. CLAUDE.md exists at the repo root.
+**Depth:** [Chapter 02 -- Project Bootstrap](guide/02-project-bootstrap.md)
+
+## Phase 3: Specify (Chapter 03)
+
+**You:** Generate the full document cascade. Review each document before the agent writes the next one.
+
+> Read `docs/interview-summary.md` and produce the specification documents in this order, waiting for
+> my approval after each one:
+>
+> 1. `docs/prd.md` — Product Requirements Document
+> 2. `docs/architecture.md` — Architecture and tech decisions
+> 3. `docs/ux-spec.md` — UX specification with screen inventory
+> 4. `contracts/api.yaml` — OpenAPI contract
+> 5. `docs/brand-identity.md` — Visual language and component conventions
+>
+> Use the corresponding templates in `templates/docs/` and `templates/contracts/`. Each document
+> should reference the ones before it, not reinvent details.
+
+**Verify:** All five documents exist, are internally consistent, and reference each other.
+**Depth:** [Chapter 03 -- Specification Phase](guide/03-specification-phase.md)
+
+## Phase 4: Build the Harness (Chapters 04, 06, 07)
+
+**You:** Set up the context hierarchy, design-intent rules, and quality gates before writing any
+application code.
+
+> Based on the specification documents in `docs/` and `contracts/`, create the harness:
+>
+> 1. Path-scoped rules in `.claude/rules/` for backend, frontend, testing, and database conventions
+> 2. A design-intent skill in `.claude/skills/` that enforces brand identity on UI work
+> 3. Hook configurations for linting and type-checking on pre-commit
+> 4. Update CLAUDE.md to reference these new harness files
+>
+> Do not write application code yet — this phase is infrastructure only.
+
+**Verify:** Rules autoload when you touch a matching path. Hooks fire on commit. CLAUDE.md stays under
+200 lines.
+**Depth:** [Chapter 04 -- Context Architecture](guide/04-context-architecture.md) |
+[Chapter 06 -- Design Intent](guide/06-design-intent.md) |
+[Chapter 07 -- Quality Gates](guide/07-quality-gates.md)
+
+## Phase 5: Decompose (Chapter 08)
+
+**You:** Break the PRD into numbered implementation phases before building anything.
+
+> Read `docs/prd.md` and `docs/architecture.md`. Decompose the MVP into numbered implementation
+> phases (aim for 3-6). Each phase should be independently testable and produce a working increment.
+> Write the phase plan to `docs/phase-plan.md` with acceptance criteria for each phase.
+
+**Verify:** Each phase has clear boundaries, acceptance criteria, and no circular dependencies.
+**Depth:** [Chapter 08 -- Implementation](guide/08-implementation.md)
+
+## Phase 6: Implement — Repeat Per Phase (Chapter 08)
+
+**You:** Execute one phase at a time. Do not skip the acceptance criteria check.
+
+> Implement Phase [N] from `docs/phase-plan.md`.
+>
+> **Build:** Read the phase description, acceptance criteria, and all referenced spec documents.
+> Implement the phase. Run all linters, type checkers, and tests before marking it complete.
+>
+> **Do NOT:** Modify code outside this phase's scope. Skip tests. Add features not in the spec.
+> Disable linters or type checkers to make code pass. Use `any` types or `@ts-ignore` as shortcuts.
+>
+> **Acceptance criteria:** All items from the phase plan pass. The integration smoke test passes.
+> No regressions in prior phases.
+
+**Verify:** Run the integration smoke test. Manually verify the increment works end to end. Commit.
+**Depth:** [Chapter 08 -- Implementation](guide/08-implementation.md)
+
+## Phase 7: Ship (Chapter 09)
+
+**You:** Set up CI/CD and deployment configuration. The agent writes the pipeline; you execute the
+deployment.
+
+> Create the CI/CD pipeline and deployment configuration:
+>
+> 1. `.github/workflows/ci.yml` — lint, type-check, test on every PR
+> 2. `.github/workflows/release.yml` — build and publish on tag
+> 3. `Dockerfile` and `docker-compose.yml` for production deployment
+> 4. Environment variable documentation in `docs/deployment.md`
+>
+> Reference `docs/architecture.md` for infrastructure decisions. Do not hardcode secrets — use
+> environment variable placeholders.
+
+**Verify:** CI passes on a test PR. Docker build succeeds locally.
+**Depth:** [Chapter 09 -- CI/CD and Deployment](guide/09-ci-cd-and-deployment.md)
+
+## Phase 8: Sustain (Chapter 10)
+
+**You:** Establish the practices that prevent codebase decay over time.
+
+> Review the current state of the codebase and set up sustainability practices:
+>
+> 1. Verify CLAUDE.md is current and under 200 lines
+> 2. Check that all rules and skills still match the actual codebase patterns
+> 3. Create any missing skills for patterns that required manual correction more than once
+> 4. Update `docs/` to reflect what was actually built vs. what was planned
+
+**Verify:** A fresh Claude Code session can orient itself using only CLAUDE.md and the harness files.
+**Depth:** [Chapter 10 -- Entropy Management](guide/10-entropy-management.md)
+
+---
+
+## Further Reading
+
+- [Chapter 11 -- Failure Modes](guide/11-failure-modes.md) — What goes wrong and how to fix it
+- [`checklists/`](checklists/) — Verification checklists for kickoff, phase completion, context reset, and pre-merge
+- [`templates/`](templates/) — Starter files for CLAUDE.md, spec documents, contracts, and harness configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,8 @@ Sources of truth and their dependents. Check dependents after any change to the 
 
 | Source of Truth                         | Dependents to Check                                                 |
 |-----------------------------------------|---------------------------------------------------------------------|
-| Chapter H1 titles (`guide/*.md` line 1) | `README.md` lines 45-93, `CLAUDE.md`, "Next:" link in prior chapter |
-| Template paths (referenced in chapters) | Actual files in `templates/`                                        |
+| Chapter H1 titles (`guide/*.md` line 1) | `README.md` lines 45-93, `CLAUDE.md`, `CHEATSHEET.md`, "Next:" link in prior chapter |
+| Template paths (referenced in chapters) | Actual files in `templates/`, `CHEATSHEET.md`                       |
 | "five-tier context hierarchy" (Ch 04)   | `CLAUDE.md`, `README.md`                                            |
 | "document cascade" (Ch 03)              | `CLAUDE.md`, `README.md`, `templates/docs/README.md`                |
 | Template filenames                      | Chapter metadata lines, template `README.md` files                  |

--- a/README.md
+++ b/README.md
@@ -103,14 +103,17 @@ Standalone checklists for key moments in the project lifecycle:
 
 ## Quick Start
 
-**Option A: Read the guide from the beginning.**
+**Option A: Follow the cheatsheet.**
+[`CHEATSHEET.md`](CHEATSHEET.md) is a copy-paste-ready quick reference with prompts for every lifecycle phase.
+
+**Option B: Read the guide from the beginning.**
 Start with [Chapter 01](guide/01-foundations.md) and follow the sequence.
 
-**Option B: Copy the templates into an existing project.**
+**Option C: Copy the templates into an existing project.**
 Browse the [`templates/`](templates/) directory for starter files you can drop into your repo: CLAUDE.md templates, doc
 templates, OpenAPI stubs, and skill definitions.
 
-**Option C: Jump to a specific topic.**
+**Option D: Jump to a specific topic.**
 Each chapter is self-contained enough to read independently, though the concepts build on each other.
 
 ## Sources and Further Reading


### PR DESCRIPTION
## Summary

- Adds `CHEATSHEET.md` — a concise quick-reference with copy-paste prompts for all 9 phases (0-8) of a harness-engineered project, each with a human action, blockquote agent prompt, verify step, and chapter link
- Updates `README.md` Quick Start to feature the cheatsheet as Option A
- Extends the cross-reference registry in `CLAUDE.md` to include `CHEATSHEET.md` as a dependent of chapter titles and template paths
- Adds `CHEATSHEET.md` to the `root-files.md` rule with constraints (under 200 lines, 9 phases, square-bracket placeholders)

Closes #13

## Test plan

- [ ] Verify `CHEATSHEET.md` renders correctly on GitHub and contains phases 0-8
- [ ] Confirm all chapter links in the cheatsheet resolve to existing files
- [ ] Confirm README Quick Start options A-D are properly ordered
- [ ] Confirm CLAUDE.md cross-reference registry includes `CHEATSHEET.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)