### PR TITLE
Audit CLAUDE.md format accuracy

### DIFF
--- a/guide/04-context-architecture.md
+++ b/guide/04-context-architecture.md
@@ -28,10 +28,15 @@ decision ever made. The agent needs to know *where to look*, not *everything at 
 
 ## The Five Tiers of Context
 
-### Tier 1: CLAUDE.md — Always Loaded (~200 lines)
+### Tier 1: CLAUDE.md — Always Loaded
 
-CLAUDE.md sits at your project root. Claude Code loads it automatically at the start of every session. It is the most
-valuable and most constrained piece of context you will write.
+CLAUDE.md lives at your project root — either `./CLAUDE.md` or `./.claude/CLAUDE.md`. Claude Code loads it automatically
+at the start of every session. It also walks up the directory tree above your working directory, loading any CLAUDE.md
+files it finds along the way, and loads a user-level file at `~/.claude/CLAUDE.md` for personal preferences that span all
+projects. CLAUDE.md files in subdirectories load on demand when the agent reads files in those directories.
+
+CLAUDE.md is loaded in full regardless of length — there is no truncation. But target under 200 lines per file. Past that
+threshold, attention dilution causes the agent to miss rules buried in the middle.
 
 **What it is:** A table of contents and a set of invariant rules. Not an encyclopedia.
 
@@ -93,6 +98,12 @@ npm run dev # frontend
 
 Notice what is *absent*: no architecture rationale, no design token values, no deployment procedures. Those live in
 deeper tiers.
+
+**Splitting a large CLAUDE.md:** If your file grows beyond 200 lines, three strategies keep it lean: move file-specific
+instructions to path-scoped rules (Tier 2), move work-type-specific instructions to skills (Tier 3), or use
+`@path/to/file` imports to factor sections into separate files that are expanded inline at load time. Imports keep the
+content always-loaded but in separate, maintainable files — useful for large reference tables or team conventions. Rules
+and skills provide true progressive disclosure, loading context only when relevant.
 
 **The OpenAI lesson:** The `AGENTS.md` pattern — one large file containing everything — emerged as an alternative
 approach. As discussed in their [Harness Engineering](https://openai.com/index/harness-engineering/) blog, OpenAI found

--- a/guide/10-entropy-management.md
+++ b/guide/10-entropy-management.md
@@ -55,6 +55,8 @@ Discard: earlier exploration of WebSocket alternatives and the prompt builder di
 
 Without focus instructions, `/compact` compresses everything equally, which may preserve the noise you want to discard. With focus instructions, it prioritizes the signal.
 
+**CLAUDE.md survives compaction.** After `/compact`, Claude Code re-reads your CLAUDE.md from disk and injects it fresh into the session. Instructions in CLAUDE.md are never lost to compaction. If an instruction disappeared after compacting, it was given only in conversation — add it to CLAUDE.md to make it persist across resets.
+
 ### What the Human Should Do
 
 Develop a habit of starting each work block with a fresh context. Before giving the agent a task, ask: "Is the current context helping or hurting?" If the answer is not clearly "helping," `/clear`.


### PR DESCRIPTION
Closes #16

## Summary

Audited every reference to CLAUDE.md across the entire repository against the official documentation at https://code.claude.com/docs/en/memory. Found and fixed 5 inaccuracies in Chapters 04 and 10; confirmed all other references (code blocks, templates, repo CLAUDE.md, prose claims) are accurate.

### Inaccuracies fixed

**Chapter 04 — Context Architecture (Tier 1 section):**
- **Location**: Said "CLAUDE.md sits at your project root" — now correctly states it can be at `./CLAUDE.md` or `./.claude/CLAUDE.md`, mentions walk-up directory loading, user-level file at `~/.claude/CLAUDE.md`, and subdirectory on-demand loading
- **Truncation misconception**: Header said `(~200 lines)` which could imply truncation — now clarifies "loaded in full regardless of length" with the 200-line guideline framed as an effectiveness recommendation
- **Missing feature**: Added `@path/to/file` import syntax as a third strategy (alongside rules and skills) for keeping CLAUDE.md under 200 lines

**Chapter 10 — Entropy Management (/compact section):**
- **Compaction survival**: Added that CLAUDE.md fully survives `/compact` — re-read from disk and injected fresh

### Confirmed accurate (no changes needed)
- All fenced code blocks showing CLAUDE.md content use standard markdown (correct per official docs)
- `templates/CLAUDE.md` — correct format, appropriate sections, CUSTOMIZE markers
- This repo's own `CLAUDE.md` — correct format, under 200 lines, meaningful content
- Prose claims in Ch01, Ch02, Ch03, Ch06, Ch07, Ch08, Ch09, Ch11, CHEATSHEET.md, checklists — all accurate
- Lane discipline maintained: no changes to hooks, skills, rules, settings, or subagent content

### Validation
- Cross-reference check passes (7 false positives from illustrative examples, 0 real issues)
- All 11 chapter H1 titles match README.md
- All Next: footer links chain correctly
- Canonical terms ("five-tier context hierarchy", "document cascade") used consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)