### PR TITLE
Audit path-scoped rules format accuracy

### DIFF
--- a/guide/01-foundations.md
+++ b/guide/01-foundations.md
@@ -14,7 +14,7 @@ Harness engineering is the discipline of designing environments that make AI age
 In Claude Code, the harness consists of:
 
 - **CLAUDE.md** -- The root configuration file that tells the agent what the project is, how to build it, and what rules to follow
-- **Rules** (`.claude/rules/`) -- Scoped instructions that activate based on file patterns or contexts
+- **Rules** (`.claude/rules/`) -- Scoped instructions that activate when Claude reads files matching their path patterns
 - **Skills** (`.claude/skills/`) -- Reusable instruction sets the agent can invoke for specific tasks
 - **Hooks** -- Pre- and post-action scripts that enforce constraints automatically (linting on save, tests before commit)
 - **Design documents** (`docs/`) -- PRD, architecture, UX spec, API contracts, brand identity
@@ -157,7 +157,7 @@ Fixes have different scopes and different persistence levels. Choose the right r
 | Scope | Mechanism | Persistence | When to Use |
 |-------|-----------|-------------|-------------|
 | This conversation only | Tell the agent directly | Dies when conversation ends | Truly one-off corrections |
-| This file pattern | `.claude/rules/` with glob | Persists across conversations | Pattern-specific guidance (e.g., "all migration files must...") |
+| This file pattern | `.claude/rules/` with `paths` frontmatter | Persists across conversations | Pattern-specific guidance (e.g., "all migration files must...") |
 | This project | CLAUDE.md | Persists across conversations | Project-wide rules and constraints |
 | This task type | `.claude/skills/` | Invoked on demand | Complex multi-step procedures |
 | This action | Hooks (pre-commit, etc.) | Runs automatically | Hard constraints that must never be violated |

--- a/guide/04-context-architecture.md
+++ b/guide/04-context-architecture.md
@@ -115,8 +115,9 @@ only when relevant.
 
 ### Tier 2: Path-Scoped Rules — Loaded on File Match
 
-Path-scoped rules live in `.claude/rules/*.md`. Each file has YAML frontmatter specifying which file paths trigger it.
-When Claude reads or edits a file matching the path pattern, the corresponding rule loads automatically.
+Path-scoped rules live in `.claude/rules/` as `.md` files, discovered recursively (subdirectories are supported). Files
+with YAML frontmatter specifying a `paths` field trigger when Claude reads matching files. Files without `paths`
+frontmatter load unconditionally at session start.
 
 **This is zero-cost context when irrelevant.** A backend rule scoped to `apps/backend/**` never loads during a
 frontend-only session. You get precision without pollution.

--- a/guide/08-implementation.md
+++ b/guide/08-implementation.md
@@ -393,13 +393,15 @@ All error responses MUST use this structure:
 [... concrete code examples ...]
 ```
 
-**Add a rule** when the guidance is short, universal, and always relevant. Rules go in `.claude/rules/` and are loaded
-automatically when files matching their glob are edited.
+**Add a rule** when the guidance is short, universal, and always relevant. Rules go in `.claude/rules/` and load
+automatically when Claude reads files matching their path patterns.
 
 ```markdown
 # .claude/rules/api-endpoints.md
-
-# globs: apps/backend/src/api/**/*.py
+---
+paths:
+  - "apps/backend/src/api/**/*.py"
+---
 
 - All endpoints return the standard error shape defined in skills/error-handling-patterns.md
 - Never return raw exception messages to clients


### PR DESCRIPTION
## Summary

Closes #17

Audited all path-scoped rules references against the [official docs](https://code.claude.com/docs/en/memory). Found and fixed 5 inaccuracies across 3 guide chapters:

- **Chapter 08 (MAJOR)**: Code block used fabricated `# globs:` comment format instead of YAML frontmatter with `paths:` field. Prose also referenced "their glob" instead of path patterns.
- **Chapter 04**: Prose said `.claude/rules/*.md` (implying flat-only discovery) and "each file has YAML frontmatter" (implying all files require it). Fixed to mention recursive discovery and that rules without `paths` frontmatter load unconditionally.
- **Chapter 01**: Description said rules "activate based on file patterns or contexts" — removed unsupported "or contexts". Feedback ladder table said "with glob" — corrected to "with `paths` frontmatter".

**No issues found in:**
- This repo's own `.claude/rules/` files (all 4 use correct `paths` frontmatter)
- Template rule file (`templates/.claude/rules/example-backend.md`)
- Lane discipline maintained — no changes to skills, hooks, CLAUDE.md format, or subagent content

## Test plan

- [x] Cross-reference check passes (all 7 findings are known false positives from example/pattern links)
- [x] Chapter H1 titles unchanged — README entries still match
- [x] No content changes outside rules-related prose and code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)