### PR TITLE
Audit memory format accuracy

### DIFF
--- a/guide/01-foundations.md
+++ b/guide/01-foundations.md
@@ -95,7 +95,7 @@ Practical mitigations:
 - Start fresh conversations for new tasks rather than continuing stale ones
 - Keep CLAUDE.md as the single source of truth, not conversation history
 - When a long conversation starts producing inconsistent results, that is your signal to start a new one
-- Use memory files (`.claude/memory/`) for facts that must persist across conversations
+- Use auto memory (`~/.claude/projects/<project>/memory/`) for facts that must persist across conversations
 
 ### Context as Cost
 

--- a/guide/04-context-architecture.md
+++ b/guide/04-context-architecture.md
@@ -319,8 +319,24 @@ contracts/
 
 ### Tier 5: Auto-Memory — Persistent Across Sessions
 
-Claude Code maintains a memory file at `~/.claude/projects/<project-hash>/memory/MEMORY.md`. This persists across
-sessions for the same project. The agent appends to it; you can also edit it manually.
+Claude Code maintains a memory directory at `~/.claude/projects/<project>/memory/`. The `<project>` path is derived from
+the git repository, so all worktrees and subdirectories within the same repo share one memory directory. The directory
+contains a `MEMORY.md` index and optional topic files:
+
+```
+~/.claude/projects/<project>/memory/
+├── MEMORY.md          # Concise index — first 200 lines loaded every session
+├── debugging.md       # Detailed notes on debugging patterns
+├── api-conventions.md # API design decisions
+└── ...                # Any other topic files Claude creates
+```
+
+The first 200 lines of `MEMORY.md` are loaded at the start of every conversation. Topic files are not loaded at
+startup — Claude reads them on demand when it needs the information. Claude keeps `MEMORY.md` concise by moving detailed
+notes into separate topic files.
+
+Auto memory is machine-local and is not shared across machines or cloud environments. You can edit or delete any memory
+file at any time — they are plain Markdown.
 
 **What to store in memory:**
 
@@ -342,7 +358,7 @@ otherwise live only in a human engineer's head. When a new session starts, memor
 what failed, what conventions emerged.
 
 **Pruning:** Memory files grow. Periodically review and remove entries that are no longer relevant (completed phases,
-resolved issues, superseded decisions). A lean memory file is more useful than a comprehensive one.
+resolved issues, superseded decisions). A lean memory directory is more useful than a comprehensive one.
 
 ---
 

--- a/guide/05-agent-orchestration.md
+++ b/guide/05-agent-orchestration.md
@@ -114,7 +114,7 @@ Do not modify files. Report findings only.
 Key frontmatter fields: `name` (unique identifier), `description` (routing trigger — see below), `tools`
 (allowlist; omit to inherit all tools), `model` (`haiku`, `sonnet`, `opus`, or `inherit`), `background`
 (`true` to run async), `isolation` (`worktree` for an isolated git worktree), `memory` (persistence scope:
-`user`, `project`, or `local` — stored at `.claude/agent-memory/<name>/`), `skills` (list of skills to
+`user`, `project`, or `local` — path varies by scope), `skills` (list of skills to
 preload into the subagent's context). See the
 [official subagent documentation](https://code.claude.com/docs/en/sub-agents) for the full field reference.
 
@@ -226,14 +226,20 @@ is consistent across all usages."
 
 ### Persistent memory
 
-The `memory` frontmatter field gives subagents cross-session continuity. When set to `project` (recommended),
-Claude Code stores the subagent's memory at `.claude/agent-memory/<name>/`. This directory is automatically
-loaded on each invocation — the subagent picks up where it left off.
+The `memory` frontmatter field gives subagents cross-session continuity. The storage path depends on scope:
+
+| Scope     | Location                                      | Use when                                                               |
+|-----------|-----------------------------------------------|------------------------------------------------------------------------|
+| `user`    | `~/.claude/agent-memory/<name>/`              | The subagent should remember learnings across all projects             |
+| `project` | `.claude/agent-memory/<name>/`                | The subagent's knowledge is project-specific and shareable via VCS     |
+| `local`   | `.claude/agent-memory-local/<name>/`          | The subagent's knowledge is project-specific but should not be checked in |
+
+Use `project` (recommended) for most cases. It makes subagent knowledge shareable via version control.
 
 **How it works:**
 
 - The subagent's `MEMORY.md` index (first 200 lines) is autoloaded at startup
-- The subagent reads and writes memory files in its `.claude/agent-memory/<name>/` directory
+- The subagent reads and writes memory files in its memory directory
 - Memory persists across sessions — shut down, restart, and the subagent remembers
 
 **What to store in agent memory:**


### PR DESCRIPTION
Closes #20

## Summary

Audited all memory-related content across the entire repo against the [official Claude Code memory docs](https://code.claude.com/docs/en/memory) and [subagent docs](https://code.claude.com/docs/en/sub-agents#enable-persistent-memory). Found and fixed three inaccuracies:

- **Ch01 (Foundations)**: `.claude/memory/` is a fabricated path — corrected to `~/.claude/projects/<project>/memory/`
- **Ch04 (Context Architecture)**: Tier 5 section described a single "memory file" at `<project-hash>` path — corrected to describe the memory *directory* model (MEMORY.md index + topic files), fixed path to `<project>`, added directory structure example, documented 200-line loading behavior and machine-local scope
- **Ch05 (Agent Orchestration)**: Frontmatter summary claimed a single storage path for all three memory scopes — corrected to "path varies by scope"; expanded the Persistent Memory section with a scope/location/use-when table showing all three paths (`user`, `project`, `local`)

### Lane discipline

No changes were made to content belonging to other mechanisms (hooks, skills, rules, settings, CLAUDE.md format). Behavioral guidance in checklists, templates, and Ch08 was verified as accurate and left unchanged.

### Cross-reference check

Automated validation script: 7 findings, all false positives (illustrative link examples in rule/skill files). Manual checks (chapter titles, canonical terms, Next: footers) all pass.

## Test plan

- [ ] Verify Ch04 Tier 5 section accurately describes auto memory directory structure per official docs
- [ ] Verify Ch05 persistent memory table matches official subagent docs scope/path mappings
- [ ] Verify Ch01 memory path is correct
- [ ] Confirm no other files were changed (lane discipline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)