### PR TITLE
Audit hooks format accuracy

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -67,16 +67,16 @@ application code.
 >
 > 1. Path-scoped rules in `.claude/rules/` for backend, frontend, testing, and database conventions
 > 2. A design-intent skill in `.claude/skills/` that enforces brand identity on UI work
-> 3. Hook configurations for linting and type-checking on pre-commit
+> 3. Hook configurations in `.claude/settings.json` for linting and type-checking after file edits
 > 4. Update CLAUDE.md to reference these new harness files
 > 5. A security-review skill in `.claude/skills/` covering input validation, parameterized queries,
 >    auth checks, and OWASP Top 10 awareness
-> 6. A pre-commit hook that blocks commits containing hardcoded secrets (API keys, tokens, passwords)
+> 6. A `PreToolUse` hook that blocks file writes containing hardcoded secrets (API keys, tokens, passwords)
 >
 > Do not write application code yet — this phase is infrastructure only.
 
-**Verify:** Rules autoload when you touch a matching path. Hooks fire on commit. CLAUDE.md stays under
-200 lines.
+**Verify:** Rules autoload when you touch a matching path. Hooks fire on tool events (file edits, shell commands).
+CLAUDE.md stays under 200 lines.
 **Depth:** [Chapter 04 -- Context Architecture](guide/04-context-architecture.md) |
 [Chapter 06 -- Design Intent](guide/06-design-intent.md) |
 [Chapter 07 -- Quality Gates](guide/07-quality-gates.md)

--- a/guide/01-foundations.md
+++ b/guide/01-foundations.md
@@ -16,7 +16,7 @@ In Claude Code, the harness consists of:
 - **CLAUDE.md** -- The root configuration file that tells the agent what the project is, how to build it, and what rules to follow
 - **Rules** (`.claude/rules/`) -- Scoped instructions that activate when Claude reads files matching their path patterns
 - **Skills** (`.claude/skills/`) -- Reusable instruction sets the agent can invoke for specific tasks
-- **Hooks** -- Pre- and post-action scripts that enforce constraints automatically (linting on save, tests before commit)
+- **Hooks** -- Scripts that run automatically on tool events (linting after file edits, blocking secret writes)
 - **Design documents** (`docs/`) -- PRD, architecture, UX spec, API contracts, brand identity
 - **Contracts** (`contracts/`) -- Formal interface definitions (OpenAPI YAML) that serve as the source of truth between system boundaries
 
@@ -160,7 +160,7 @@ Fixes have different scopes and different persistence levels. Choose the right r
 | This file pattern | `.claude/rules/` with `paths` frontmatter | Persists across conversations | Pattern-specific guidance (e.g., "all migration files must...") |
 | This project | CLAUDE.md | Persists across conversations | Project-wide rules and constraints |
 | This task type | `.claude/skills/` | Invoked on demand | Complex multi-step procedures |
-| This action | Hooks (pre-commit, etc.) | Runs automatically | Hard constraints that must never be violated |
+| This action | Hooks (PreToolUse, PostToolUse, etc.) | Runs automatically | Hard constraints that must never be violated |
 | This knowledge | Memory files | Persists across conversations | Facts, decisions, lessons learned |
 
 ### Concrete Example
@@ -174,7 +174,7 @@ You ask Claude to build a REST endpoint. It works, but it returns `camelCase` fi
 All API response fields use snake_case naming. This is enforced by the OpenAPI contract in contracts/openapi.yaml.
 ```
 
-**Strongest fix**: Add a pre-commit hook that runs contract validation, so snake_case violations are caught automatically before code is committed.
+**Strongest fix**: Add a `PostToolUse` hook on `Edit|Write` that runs contract validation, so snake_case violations are caught automatically after every file edit.
 
 Each rung of the ladder makes the fix more durable. Over the course of a project, dozens of these accumulated fixes transform a bare harness into a finely tuned one that produces correct output on the first try.
 

--- a/guide/07-quality-gates.md
+++ b/guide/07-quality-gates.md
@@ -34,8 +34,9 @@ accumulating errors.
 
 ### Level 1: Hooks — Automatic, After Every Edit
 
-Hooks are scripts that run automatically after Claude Code edits a file. They are configured in `.claude/hooks/` and
-execute without agent intervention. The agent sees the output — including errors — and can react immediately.
+Hooks are scripts that run automatically when Claude Code uses a tool. They are configured in `.claude/settings.json`
+(or `~/.claude/settings.json` for global hooks) and execute outside the LLM — they are deterministic scripts, not
+AI-generated responses. The agent sees the output — including errors — and can react immediately.
 
 **What hooks are good for:**
 
@@ -52,19 +53,26 @@ execute without agent intervention. The agent sees the output — including erro
 
 **Hook configuration:**
 
-Claude Code hooks are defined in `.claude/hooks/` or in your project's Claude Code settings. They specify a trigger (
-file pattern), a command, and an error behavior.
+Claude Code hooks are defined in `.claude/settings.json`. They specify an event type (when to fire), a `matcher` (which
+tool triggers the hook), and one or more handler commands. Hooks receive context about the tool invocation as JSON on
+stdin and use exit codes to signal results: exit 0 for success (output added to the agent's context), exit 2 to block
+the action (for `PreToolUse` hooks), or any other exit code for a non-blocking error.
 
 **Example: Python linting after every edit**
 
 ```json
 {
   "hooks": {
-    "afterEdit": [
+    "PostToolUse": [
       {
-        "match": "**/*.py",
-        "command": "ruff check --fix ${file}",
-        "onError": "warn"
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd apps/backend && ruff check --fix . 2>&1 | head -20",
+            "timeout": 30
+          }
+        ]
       }
     ]
   }
@@ -76,11 +84,16 @@ file pattern), a command, and an error behavior.
 ```json
 {
   "hooks": {
-    "afterEdit": [
+    "PostToolUse": [
       {
-        "match": "**/*.{ts,tsx}",
-        "command": "tsc --noEmit --pretty",
-        "onError": "warn"
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd apps/frontend && npx tsc --noEmit --pretty 2>&1 | head -20",
+            "timeout": 60
+          }
+        ]
       }
     ]
   }
@@ -446,13 +459,22 @@ Invoke after implementing any of:
 
 **Secret scanning hook:**
 
+A `PreToolUse` hook on `Write` can inspect file content before it is written. The hook receives the proposed content as
+JSON on stdin (in `tool_input.content`). Exit code 2 blocks the write; exit 0 allows it.
+
 ```json
 {
   "hooks": {
-    "preCommit": [
+    "PreToolUse": [
       {
-        "command": "git diff --cached --diff-filter=d | grep -iE '(api_key|secret|password|token)\\s*=\\s*[\"\\x27][^\"\\x27]+' && echo 'BLOCKED: Possible secret in commit' && exit 1 || exit 0",
-        "onError": "block"
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/check-for-secrets.sh",
+            "statusMessage": "Scanning for hardcoded secrets..."
+          }
+        ]
       }
     ]
   }
@@ -488,38 +510,56 @@ review and potentially rewriting endpoints. Front-load the investment.
 
 ## Hook Configuration in Detail
 
-Hooks in Claude Code run scripts at defined trigger points. The key trigger points:
+Hooks in Claude Code run scripts at defined trigger points based on tool events. They are configured in
+`.claude/settings.json`. The event types most relevant to quality gates:
 
-**afterEdit** — Runs after Claude edits a file. Best for: linting, formatting, quick type checks.
+**PostToolUse** — Runs after a tool succeeds. Best for: linting, formatting, quick type checks after file edits. The
+`matcher` field specifies which tool triggers the hook (e.g., `Edit|Write` for file modifications). Output is added to
+the agent's context. PostToolUse hooks cannot block — the tool already executed.
 
-**preCommit** — Runs before Claude creates a commit. Best for: secret scanning, test execution, build verification.
+**PreToolUse** — Runs before a tool executes. Can block the action when the hook returns exit code 2. Best for:
+preventing dangerous operations, scanning for secrets before a file is written.
+
+For a complete list of hook events (including `Notification`, `Stop`, `SubagentStop`, and others), see the
+[official hooks documentation](https://code.claude.com/docs/en/hooks).
 
 **Configuration patterns:**
 
 ```json
 {
   "hooks": {
-    "afterEdit": [
+    "PostToolUse": [
       {
-        "match": "**/*.py",
-        "command": "ruff check --fix ${file} && ruff format ${file}",
-        "onError": "warn"
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd apps/backend && ruff check --fix . && ruff format . 2>&1 | head -20",
+            "timeout": 30
+          }
+        ]
       },
       {
-        "match": "**/*.{ts,tsx}",
-        "command": "npx eslint --fix ${file}",
-        "onError": "warn"
-      },
-      {
-        "match": "**/*.{ts,tsx}",
-        "command": "npx tsc --noEmit --pretty 2>&1 | head -20",
-        "onError": "warn"
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd apps/frontend && npx tsc --noEmit --pretty 2>&1 | head -20",
+            "timeout": 60
+          }
+        ]
       }
     ],
-    "preCommit": [
+    "PreToolUse": [
       {
-        "command": "pytest apps/backend/tests/ -x -q --tb=short",
-        "onError": "block"
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/check-for-secrets.sh",
+            "statusMessage": "Scanning for secrets..."
+          }
+        ]
       }
     ]
   }
@@ -529,16 +569,16 @@ Hooks in Claude Code run scripts at defined trigger points. The key trigger poin
 **Design principles for hooks:**
 
 1. **Keep them fast.** Hooks run frequently. A hook that takes 10 seconds disrupts the flow. Target under 2 seconds for
-   afterEdit hooks, under 30 seconds for preCommit hooks.
+   PostToolUse hooks. Set explicit `timeout` values to prevent runaway commands.
 
-2. **Use `warn` for non-critical issues.** The agent sees the warning and can fix it. Use `block` only for issues that
-   must be fixed before proceeding (secrets in commits, failing critical tests).
+2. **Use PostToolUse for advisory checks.** The agent sees the output and can fix issues. Use PreToolUse with exit
+   code 2 only for checks that must pass before the action proceeds (e.g., blocking a file write that contains secrets).
 
-3. **Include remediation in error output.** The agent reads hook error messages. A good error message tells the agent
-   exactly what to do. A bad error message requires the agent to investigate.
+3. **Include remediation in error output.** The agent reads hook output. A good error message tells the agent exactly
+   what to do. A bad error message requires the agent to investigate.
 
-4. **Scope narrowly with `match` patterns.** A Python linter should not run when the agent edits a TypeScript file. Use
-   file patterns to trigger hooks only for relevant files.
+4. **Scope with `matcher` patterns.** The `matcher` is a regex against the tool name. `Edit|Write` targets file
+   modifications. `Bash` targets shell commands. `mcp__.*` targets MCP tool calls.
 
 5. **Auto-fix when possible.** `ruff check --fix` and `eslint --fix` correct issues automatically. The agent does not
    need to manually fix formatting or import ordering if the tool can do it.
@@ -547,8 +587,8 @@ Hooks in Claude Code run scripts at defined trigger points. The key trigger poin
 
 ## What the Human Should Do
 
-1. **Set up hooks early.** Before the first agent session, configure afterEdit hooks for linting and formatting. This is
-   15 minutes of setup that prevents hundreds of manual corrections.
+1. **Set up hooks early.** Before the first agent session, configure `PostToolUse` hooks for linting and formatting. This
+   is 15 minutes of setup that prevents hundreds of manual corrections.
 
 2. **Write the integration smoke test.** Start with health checks and auth flow. Expand as features land. Run it after
    every agent phase — this is your responsibility, not the agent's.
@@ -569,7 +609,7 @@ Hooks in Claude Code run scripts at defined trigger points. The key trigger poin
 
 ## What the Agent Should Do
 
-1. **Fix hook failures immediately.** When an afterEdit hook reports an error, fix it in the next edit. Do not
+1. **Fix hook failures immediately.** When a `PostToolUse` hook reports an error, fix it in the next edit. Do not
    accumulate lint errors across a phase.
 
 2. **Run tests incrementally.** After changing a module, run its test file. After completing a phase, run the full

--- a/guide/09-ci-cd-and-deployment.md
+++ b/guide/09-ci-cd-and-deployment.md
@@ -142,7 +142,7 @@ service containers. This catches SQL-dialect differences that mocks hide.
 Agent-generated code fails CI for predictable reasons. Knowing the patterns helps you fix them quickly.
 
 **Import ordering and formatting.** The agent writes code that works but may not match your linter's expectations. Fix
-this with pre-commit hooks (Chapter 6) so formatting issues never reach CI.
+this with pre-commit hooks (Chapter 7) so formatting issues never reach CI.
 
 **Missing dependencies.** The agent uses a library in code but does not add it to `requirements.txt` or `package.json`.
 The fix: include dependency management in your CLAUDE.md or subagent definitions. "When you import a new package, add it

--- a/guide/10-entropy-management.md
+++ b/guide/10-entropy-management.md
@@ -292,7 +292,8 @@ Some entropy can be detected and fixed automatically. This is the highest-levera
 
 ### Pre-commit hooks
 
-Chapter 6 covered hooks in detail. In the context of entropy management, hooks serve as automatic formatters:
+Chapter 7 covered Claude Code hooks in detail. For git commit-time automation, the
+[pre-commit framework](https://pre-commit.com/) serves as an automatic formatter:
 
 ```yaml
 # .pre-commit-config.yaml

--- a/templates/.claude/hooks/README.md
+++ b/templates/.claude/hooks/README.md
@@ -4,52 +4,70 @@
 Hooks are deterministic scripts that run automatically on tool events (before/after
 file edits, command execution, etc.). Unlike skills (which rely on the agent choosing
 to invoke them), hooks fire mechanically every time. Use them for guardrails that must
-never be skipped: linting after edits, blocking secret commits, enforcing file boundaries. -->
+never be skipped: linting after edits, blocking secret writes, enforcing file boundaries. -->
 
 ## What Are Hooks?
 
-Hooks are shell commands configured in `.claude/settings.json` that run on specific
-Claude Code tool events. They execute outside the LLM -- they are deterministic scripts,
-not AI-generated responses. This makes them reliable for enforcement tasks.
+Hooks are commands configured in `.claude/settings.json` that run on specific Claude Code tool
+events. They execute outside the LLM -- they are deterministic scripts, not AI-generated responses.
+This makes them reliable for enforcement tasks.
 
-**Hook types:**
-- `PreToolUse` -- runs BEFORE a tool executes (can block the action)
-- `PostToolUse` -- runs AFTER a tool executes (can report issues)
+**Key event types:**
+- `PreToolUse` -- runs BEFORE a tool executes (can block the action with exit code 2)
+- `PostToolUse` -- runs AFTER a tool succeeds (output added to agent context)
+- `PostToolUseFailure` -- runs AFTER a tool fails
 
-**Matching:** Hooks specify a `matcher` (the tool name) and optional `filePath` patterns
-to scope when they fire.
+Other events include `Stop`, `SubagentStop`, `Notification`, `UserPromptSubmit`, and more. See the
+[official hooks documentation](https://code.claude.com/docs/en/hooks) for the complete list.
+
+**Matching:** Hooks specify a `matcher` (a regex pattern matched against the tool name) to scope
+when they fire. For example, `Edit|Write` matches file edit tools, `Bash` matches shell commands,
+and `mcp__.*` matches any MCP tool.
 
 ## Configuration
 
 Add hooks to `.claude/settings.json`:
 
+**[CUSTOMIZE]** Replace the linter commands, directory paths, and script paths below with your
+project's actual tools and structure.
+
 ```json
 {
   "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hook": "cp \"$CLAUDE_FILE_PATH\" \"$CLAUDE_FILE_PATH.bak\" 2>/dev/null || true",
-        "description": "Backup file before modification"
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "filePath": "\\.py$",
-        "hook": "cd apps/backend && ruff check --fix \"$CLAUDE_FILE_PATH\" 2>&1 | tail -5",
-        "description": "Auto-lint Python files after edit"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd apps/backend && ruff check --fix . 2>&1 | head -20",
+            "timeout": 30,
+            "statusMessage": "Linting Python files..."
+          }
+        ]
       },
       {
         "matcher": "Edit|Write",
-        "filePath": "\\.(ts|tsx)$",
-        "hook": "cd apps/frontend && npx tsc --noEmit 2>&1 | head -20",
-        "description": "Type-check TypeScript files after edit"
-      },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd apps/frontend && npx tsc --noEmit 2>&1 | head -20",
+            "timeout": 60,
+            "statusMessage": "Type-checking TypeScript..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
       {
-        "matcher": "Edit|Write",
-        "hook": "grep -rn 'AKIA\\|sk-\\|password\\s*=' \"$CLAUDE_FILE_PATH\" && echo 'WARNING: Possible hardcoded secret detected' || true",
-        "description": "Scan for hardcoded secrets after any file edit"
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "scripts/check-for-secrets.sh",
+            "statusMessage": "Scanning for hardcoded secrets..."
+          }
+        ]
       }
     ]
   }
@@ -58,53 +76,57 @@ Add hooks to `.claude/settings.json`:
 
 ## Hook Examples
 
-### Pre-Edit: Backup Before Modification
+### PostToolUse: Lint Python Files
 
-Creates a `.bak` copy of any file before Claude edits it. Useful during early development
-when you want an easy rollback path.
+Runs ruff on the backend directory after any file edit. Catches lint errors before they
+accumulate. The `--fix` flag auto-corrects simple issues.
 
 ```json
 {
   "matcher": "Edit|Write",
-  "hook": "cp \"$CLAUDE_FILE_PATH\" \"$CLAUDE_FILE_PATH.bak\" 2>/dev/null || true"
+  "hooks": [
+    {
+      "type": "command",
+      "command": "cd apps/backend && ruff check --fix . 2>&1 | tail -5",
+      "timeout": 30
+    }
+  ]
 }
 ```
 
-### Post-Edit: Lint Python Files
+### PostToolUse: Type-Check TypeScript
 
-Runs ruff on any Python file immediately after it is modified. Catches lint errors before
-they accumulate. The `--fix` flag auto-corrects simple issues.
+Runs the TypeScript compiler in check mode after any file edit. Catches type errors
+immediately instead of discovering them at build time.
 
 ```json
 {
   "matcher": "Edit|Write",
-  "filePath": "\\.py$",
-  "hook": "cd apps/backend && ruff check --fix \"$CLAUDE_FILE_PATH\" 2>&1 | tail -5"
+  "hooks": [
+    {
+      "type": "command",
+      "command": "cd apps/frontend && npx tsc --noEmit 2>&1 | head -20",
+      "timeout": 60
+    }
+  ]
 }
 ```
 
-### Post-Edit: Type-Check TypeScript
+### PreToolUse: Block Secret Writes
 
-Runs the TypeScript compiler in check mode after any `.ts` or `.tsx` edit. Catches type
-errors immediately instead of discovering them at build time.
-
-```json
-{
-  "matcher": "Edit|Write",
-  "filePath": "\\.(ts|tsx)$",
-  "hook": "cd apps/frontend && npx tsc --noEmit 2>&1 | head -20"
-}
-```
-
-### Post-Edit: Secret Detection
-
-Scans edited files for patterns that look like hardcoded secrets (AWS keys, API keys,
-password assignments). Prints a warning if found. Does not block the edit -- just alerts.
+Inspects proposed file content before it is written. The hook receives tool input as JSON on
+stdin (including `tool_input.content` for Write). Exit code 2 blocks the write; exit 0 allows it.
 
 ```json
 {
-  "matcher": "Edit|Write",
-  "hook": "grep -rn 'AKIA\\|sk-\\|password\\s*=' \"$CLAUDE_FILE_PATH\" && echo 'WARNING: Possible hardcoded secret detected' || true"
+  "matcher": "Write",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "scripts/check-for-secrets.sh",
+      "statusMessage": "Scanning for hardcoded secrets..."
+    }
+  ]
 }
 ```
 
@@ -112,7 +134,7 @@ password assignments). Prints a warning if found. Does not block the edit -- jus
 
 | Mechanism | Timing | Deterministic? | Use For |
 |-----------|--------|----------------|---------|
-| **Hooks** | Every tool event | Yes | Linting, type-checking, secret scanning, file backups |
+| **Hooks** | Every tool event | Yes | Linting, type-checking, secret scanning |
 | **Skills** | Agent invokes explicitly | No (agent must choose) | Checklists, design review, contract validation |
 | **CI** | On push / PR | Yes | Full test suite, build verification, integration tests |
 
@@ -121,17 +143,39 @@ password assignments). Prints a warning if found. Does not block the edit -- jus
 - If it requires reading context and making assessments: **skill** (make it mandatory in CLAUDE.md).
 - If it takes more than a few seconds or needs the full codebase: **CI**.
 
-## Environment Variables Available to Hooks
+## Hook Input and Output
 
-| Variable | Description |
-|----------|-------------|
-| `CLAUDE_FILE_PATH` | Absolute path of the file being edited |
-| `CLAUDE_TOOL_NAME` | Name of the tool being used (Edit, Write, Bash, etc.) |
+Hooks receive JSON on stdin with context about the tool invocation:
+
+```json
+{
+  "session_id": "abc123",
+  "cwd": "/path/to/project",
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/path/to/file.py",
+    "old_string": "...",
+    "new_string": "..."
+  }
+}
+```
+
+**Exit codes:**
+
+| Exit Code | Meaning | Behavior |
+|-----------|---------|----------|
+| **0** | Success | Stdout added to agent context (parsed as JSON if valid) |
+| **2** | Block | For PreToolUse: blocks the tool call. Stderr shown as error. |
+| **Other** | Non-blocking error | Stderr shown in verbose mode. Execution continues. |
+
+The `$CLAUDE_PROJECT_DIR` environment variable provides the project root path.
 
 ## Tips
 
 - Keep hooks fast (under 2 seconds). Slow hooks degrade the development experience.
-- Use `|| true` at the end if the hook should warn but not block.
+- For PostToolUse hooks, exit 0 so output reaches the agent. Use `|| true` if the check itself
+  might return a non-zero exit.
 - Pipe output through `head` or `tail` to keep hook output concise.
-- Test hooks manually before adding them to settings: run the command with a real file path.
+- Test hooks manually before adding them: run the command and pipe sample JSON to stdin.
 - Hooks run in the project root directory. Use `cd` to change to subdirectories if needed.
+- Set explicit `timeout` values to prevent runaway commands (default is 600 seconds).


### PR DESCRIPTION
## Summary

Closes #19

Audited all hooks references against the [official Claude Code hooks documentation](https://code.claude.com/docs/en/hooks) and fixed every inaccuracy.

### What was wrong

The guide and templates described a **fabricated hooks API** that does not exist in Claude Code:

- **Fake event names**: `afterEdit`, `preCommit` — the real events are `PostToolUse`, `PreToolUse`, etc.
- **Wrong JSON structure**: flat `command` field instead of `hooks` array with typed handler objects (`type: "command"`)
- **Non-existent fields**: `match` (should be `matcher`), `onError` (exit codes control behavior), `filePath`, `description`, `hook` (singular)
- **Fabricated environment variables**: `$CLAUDE_FILE_PATH`, `$CLAUDE_TOOL_NAME` — hooks receive context as JSON on stdin; the only real env var is `$CLAUDE_PROJECT_DIR`
- **Wrong config location**: `.claude/hooks/` directory (hooks are configured in `.claude/settings.json`)
- **Wrong chapter cross-references**: Ch09 and Ch10 referenced "Chapter 6" for hooks content that lives in Chapter 7

### Files changed

| File | Changes |
|------|---------|
| `guide/07-quality-gates.md` | Replaced all fabricated hook examples with correct format; fixed event names, field names, and JSON structure throughout |
| `templates/.claude/hooks/README.md` | Near-complete rewrite with correct structure, input/output docs, and exit code semantics |
| `guide/01-foundations.md` | Fixed hooks description and feedback ladder to use real event names |
| `CHEATSHEET.md` | Fixed hooks references to describe tool events, not commit triggers |
| `guide/09-ci-cd-and-deployment.md` | Fixed cross-reference Chapter 6 → Chapter 7 |
| `guide/10-entropy-management.md` | Fixed cross-reference Chapter 6 → Chapter 7; clarified Claude Code hooks vs. pre-commit framework |

### Lane discipline

No changes were made to content belonging to other mechanisms (skills, rules, CLAUDE.md format, memory, subagents).

### Cross-reference check

Passes. One pre-existing title mismatch for Ch06 in CHEATSHEET.md was found but is unrelated to this audit.

## Test plan

- [ ] Verify all JSON code blocks in `guide/07-quality-gates.md` use `PostToolUse`/`PreToolUse` event names with `matcher` + `hooks` array structure
- [ ] Verify `templates/.claude/hooks/README.md` has no fabricated fields (`hook`, `description`, `filePath`) or env vars (`CLAUDE_FILE_PATH`, `CLAUDE_TOOL_NAME`)
- [ ] Verify no remaining references to `afterEdit` or `preCommit` as Claude Code hook events
- [ ] Verify cross-references in Ch09 and Ch10 now point to Chapter 7 for hooks content
- [ ] Run cross-reference-check skill to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)