### PR TITLE
fix: correct Chapter 06 title in CHEATSHEET.md

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -78,7 +78,7 @@ application code.
 **Verify:** Rules autoload when you touch a matching path. Hooks fire on tool events (file edits, shell commands).
 CLAUDE.md stays under 200 lines.
 **Depth:** [Chapter 04 -- Context Architecture](guide/04-context-architecture.md) |
-[Chapter 06 -- Design Intent](guide/06-design-intent.md) |
+[Chapter 06 -- Design Intent Preservation](guide/06-design-intent.md) |
 [Chapter 07 -- Quality Gates](guide/07-quality-gates.md)
 
 ## Phase 5: Orchestrate (Chapter 05)


### PR DESCRIPTION
## Summary
- Updated CHEATSHEET.md line 81 to use the correct Chapter 06 H1 prefix: `Chapter 06 -- Design Intent Preservation` (was `Chapter 06 -- Design Intent`)
- Confirmed all cross-references pass validation

Closes #30

## Test plan
- [ ] Verify CHEATSHEET.md line 81 matches the H1 prefix of `guide/06-design-intent.md`
- [ ] Run `python3 .claude/skills/cross-reference-check/scripts/validate.py` and confirm `ALL_CLEAR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
