### PR TITLE
fix: audit subagent definitions format accuracy

### DIFF
--- a/guide/05-agent-orchestration.md
+++ b/guide/05-agent-orchestration.md
@@ -112,10 +112,12 @@ Do not modify files. Report findings only.
 `````
 
 Key frontmatter fields: `name` (unique identifier), `description` (routing trigger — see below), `tools`
-(allowlist; omit to inherit all tools), `model` (`haiku`, `sonnet`, `opus`, or `inherit`), `background`
-(`true` to run async), `isolation` (`worktree` for an isolated git worktree), `memory` (persistence scope:
-`user`, `project`, or `local` — path varies by scope), `skills` (list of skills to
-preload into the subagent's context). See the
+(allowlist; omit to inherit all tools), `disallowedTools` (denylist; removed from inherited or specified
+tools), `model` (`haiku`, `sonnet`, `opus`, a full model ID like `claude-sonnet-4-6`, or `inherit` —
+defaults to `inherit`), `permissionMode` (`default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, or
+`plan`), `background` (`true` to run async), `isolation` (`worktree` for an isolated git worktree),
+`memory` (persistence scope: `user`, `project`, or `local` — path varies by scope), `skills` (list of
+skills to preload into the subagent's context). See the
 [official subagent documentation](https://code.claude.com/docs/en/sub-agents) for the full field reference.
 
 **The definition body is the system prompt.** The Markdown below the frontmatter is the subagent's complete


### PR DESCRIPTION
## Summary

- Audited every subagent reference across the entire repo against the [official Claude Code subagent documentation](https://code.claude.com/docs/en/sub-agents)
- Found one inaccuracy in Chapter 05's key frontmatter fields summary: missing `disallowedTools` and `permissionMode` fields, and incomplete `model` field description
- All other subagent content verified accurate: code blocks, behavioral claims, memory scopes, invocation methods, and template files

Closes #22

## Test plan

- [ ] Verify the updated frontmatter fields summary in `guide/05-agent-orchestration.md` (lines 114-121) matches the [official docs](https://code.claude.com/docs/en/sub-agents#supported-frontmatter-fields)
- [ ] Confirm `disallowedTools` and `permissionMode` descriptions are accurate
- [ ] Confirm `model` field now includes full model ID option and default value
- [ ] Verify cross-reference check passes (automated check passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
