### PR TITLE
Clarify that hello-world tests scaffolding, not integration boundaries

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -43,6 +43,7 @@ stack works end to end.
 > that I can run to verify the stack works. Commit when done.
 
 **Verify:** You can run the hello-world locally and see output. CLAUDE.md exists at the repo root.
+**Note:** This verifies framework scaffolding only, not integration boundaries (DB, frontend↔backend, auth). Those are covered by the integration smoke test in [Chapter 07](guide/07-quality-gates.md).
 **Depth:** [Chapter 02 -- Project Bootstrap](guide/02-project-bootstrap.md)
 
 ## Phase 3: Specify (Chapter 03)

--- a/guide/02-project-bootstrap.md
+++ b/guide/02-project-bootstrap.md
@@ -314,6 +314,10 @@ Then verify:
 
 Each failure is diagnostic. Fix the CLAUDE.md, not the symptom. Then try again.
 
+### What This Does Not Verify
+
+This hello-world proves that the framework scaffolding works: the build runs, the server starts, and a page renders. It does **not** prove that integration boundaries work — database connectivity, frontend-to-backend communication, vector extensions, auth flows, or external API reachability. Those boundaries are verified by the integration smoke test in [Chapter 07](07-quality-gates.md) (Level 4: Integration Smoke Tests), which you run after every agent phase. Do not mistake a working hello-world for a working stack.
+
 ### Commit the Scaffold
 
 Once the first run succeeds, commit everything. This is your baseline. Every future conversation starts from this state.


### PR DESCRIPTION
Chapter 02 (guide/02-project-bootstrap.md) — Added a new ### What This Does Not Verify subsection after the diagnostic list. It explicitly states that the hello-world proves framework scaffolding only and does not verify integration boundaries (DB connectivity, frontend↔backend communication, vector extensions, auth flows, external APIs). It points readers to Chapter 07’s Level 4 integration smoke test.
Cheatsheet (CHEATSHEET.md) — Added a one-line **Note:** in Phase 2 flagging the same gap and linking to Chapter 07.
The approach keeps the hello-world deliberately minimal (it’s a harness smoke test, not an integration test) while making the gap explicit so readers don’t confuse “it runs” with “the stack works.”