### PR TITLE
fix: correct data directory path in skill scripts after installation

### DIFF
--- a/case-study-harness/claude/skills/case-study-capture/scripts/write_manual_entry.py
+++ b/case-study-harness/claude/skills/case-study-capture/scripts/write_manual_entry.py
@@ -32,7 +32,11 @@ VALID_CATEGORIES: frozenset[str] = frozenset(
     }
 )
 
-DATA_DIR: Path = Path(__file__).resolve().parent.parent.parent.parent.parent / "data"
+DATA_DIR: Path = (
+    Path(__file__).resolve().parent.parent.parent.parent.parent
+    / "case-study-harness"
+    / "data"
+)
 LOG_FILE: str = "manual-observations.jsonl"
 
 

--- a/case-study-harness/claude/skills/case-study-synthesize/scripts/read_observations.py
+++ b/case-study-harness/claude/skills/case-study-synthesize/scripts/read_observations.py
@@ -10,7 +10,7 @@ Usage:
 
 Args:
     --data-dir: Optional path to the data directory. Defaults to
-        ``case-study-harness/data/`` relative to this script's location.
+        ``case-study-harness/data/`` relative to the project root.
 """
 
 import json
@@ -29,7 +29,11 @@ LOG_FILES: dict[str, str] = {
     "tool-uses.jsonl": "tool_use",
 }
 
-DEFAULT_DATA_DIR: Path = Path(__file__).resolve().parent.parent.parent.parent.parent / "data"
+DEFAULT_DATA_DIR: Path = (
+    Path(__file__).resolve().parent.parent.parent.parent.parent
+    / "case-study-harness"
+    / "data"
+)
 
 
 def parse_args() -> Path:


### PR DESCRIPTION
## Summary
- The capture and synthesize skill scripts resolved `DATA_DIR` by traversing five parents from `__file__` then appending `/data`. This worked in the source layout (`case-study-harness/claude/skills/…`) but after `install.py` copies skills into `<target>/.claude/skills/`, the same traversal lands at the project root — writing to `<project>/data` instead of `<project>/case-study-harness/data` where the hook scripts write.
- Both `write_manual_entry.py` and `read_observations.py` now include the `case-study-harness` segment in the path so skill-written JSONL files land alongside hook-written ones.

## Test plan
- [ ] Run `install.py` against a test repo, invoke `/case-study-capture`, and verify the entry appears in `case-study-harness/data/manual-observations.jsonl` (not `data/manual-observations.jsonl`)
- [ ] Run `/case-study-synthesize` and verify `read_observations.py` reads from `case-study-harness/data/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)